### PR TITLE
Do not apply preferences changes immediately if a save button is present

### DIFF
--- a/src/preferences/index.ts
+++ b/src/preferences/index.ts
@@ -37,6 +37,10 @@ export default class CookiePreferences {
   public attachListeners(): void {
     const purposes = getAllPurposes();
     const checkboxes: { [purpose: string]: HTMLInputElement } = {};
+    const saveButton = document.getElementById(
+      "cookie-preferences__save"
+    ) as HTMLButtonElement;
+
     for (const purpose of purposes) {
       const checkbox = <HTMLInputElement | null>(
         document.getElementById(`cookie-preferences--${purpose}`)
@@ -45,6 +49,10 @@ export default class CookiePreferences {
         checkboxes[purpose] = checkbox;
         checkbox.checked = this.cookieManager.hasCookiesEnabled(purpose);
         checkbox.addEventListener("change", () => {
+          if (saveButton !== null) {
+            saveButton.disabled = false;
+            return;
+          }
           this.cookieManager.enableFunctionalCookie();
           if (checkbox.checked) {
             this.cookieManager.enableCookies(purpose);
@@ -55,7 +63,6 @@ export default class CookiePreferences {
       }
     }
 
-    const saveButton = document.getElementById("cookie-preferences__save");
     if (saveButton !== null) {
       saveButton.addEventListener("click", () => {
         this.cookieManager.enableFunctionalCookie();
@@ -70,6 +77,7 @@ export default class CookiePreferences {
         if (notification !== null) {
           notification.style.display = "none";
         }
+        saveButton.disabled = true;
       });
     }
   }

--- a/src/preferences/index.ts
+++ b/src/preferences/index.ts
@@ -37,9 +37,9 @@ export default class CookiePreferences {
   public attachListeners(): void {
     const purposes = getAllPurposes();
     const checkboxes: { [purpose: string]: HTMLInputElement } = {};
-    const saveButton = document.getElementById(
+    const saveButton = <HTMLButtonElement | null>document.getElementById(
       "cookie-preferences__save"
-    ) as HTMLButtonElement;
+    );
 
     for (const purpose of purposes) {
       const checkbox = <HTMLInputElement | null>(


### PR DESCRIPTION
Hi,

This is a PR related to the #125 issue.
As explained in the issue, currently the `save` button is added, is actually useless because changes are applied immediately anyway.
This change makes the cookies being added only when the save button is clicked, if, a save button is present.

It also toggles the button's `disable` attribute until a change is detected.

Thanks!